### PR TITLE
Gcloud deploy

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,42 @@
+# This file specifies files that are _not_ uploaded to Google Cloud
+
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+
+# "#!include" directives (which insert the entries of the given .gitignore-style
+
+# file at that point).
+
+#
+
+# For more information, run:
+
+# $ gcloud topic gcloudignore
+
+#
+
+.gcloudignore
+
+# If you would like to upload your .git directory, .gitignore file or files
+
+# from your .gitignore file, remove the corresponding line
+
+# below:
+
+.git
+.gitignore
+
+# Node.js dependencies:
+
+node_modules/
+
+# .env
+
+.env
+
+# SRC folder
+
+src/
+
+# tsconfig
+
+tsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+app.yaml

--- a/README.md
+++ b/README.md
@@ -26,3 +26,21 @@ The variables you'll need:
 (If you are enabling https traffic)
 `VITE_PATH_TO_SSL_CERT`
 `VITE_PATH_TO_SSL_KEY`
+
+# Deployment
+
+I am currently hosting this API using the GCloud App Engine. You can set up your own project by following along [here](https://cloud.google.com/appengine/docs/standard/nodejs/building-app)
+
+Once you've deployed, make sure you add the correct values to your app.yaml file. Mine are as follows:
+
+`runtime: nodejs20` (or similar)
+`entrypoint: npm run serve`
+`env_variables:`
+`  VITE_DATAMUSE_API_URL`
+`  VITE_MS_TRANSLATOR_API_URL`
+`  VITE_MS_TRANSLATOR_API_KEY`
+`  VITE_MS_TRANSLATOR_API_LOCALITY`
+`  VITE_OPENAI_API_KEY`
+`  VITE_ALLOWED_ORIGINS`
+
+Then, you can run `gcloud app deploy` to deploy

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The variables you'll need:
 
 I am currently hosting this API using the GCloud App Engine. You can set up your own project by following along [here](https://cloud.google.com/appengine/docs/standard/nodejs/building-app)
 
-Once you've deployed, make sure you add the correct values to your app.yaml file. Mine are as follows:
+Once you've deployed, make sure you add your app.yaml file to the base of the api and include some or all of the following values:
 
 `runtime: nodejs20` (or similar)
 `entrypoint: npm run serve`

--- a/app.yaml
+++ b/app.yaml
@@ -1,9 +1,0 @@
-runtime: nodejs20
-entrypoint: npm run serve
-env_variables:
-  VITE_DATAMUSE_API_URL: https://api.datamuse.com
-  VITE_MS_TRANSLATOR_API_URL: https://api.cognitive.microsofttranslator.com
-  VITE_MS_TRANSLATOR_API_KEY: e3fe55d31ab945b89095db07e8158b89
-  VITE_MS_TRANSLATOR_API_LOCALITY: centralus
-  VITE_OPENAI_API_KEY: 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
-  VITE_ALLOWED_ORIGINS: https://localhost:3000,https://grand-cajeta-92ed93.netlify.app

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,9 @@
+runtime: nodejs20
+entrypoint: npm run serve
+env_variables:
+  VITE_DATAMUSE_API_URL: https://api.datamuse.com
+  VITE_MS_TRANSLATOR_API_URL: https://api.cognitive.microsofttranslator.com
+  VITE_MS_TRANSLATOR_API_KEY: e3fe55d31ab945b89095db07e8158b89
+  VITE_MS_TRANSLATOR_API_LOCALITY: centralus
+  VITE_OPENAI_API_KEY: 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
+  VITE_ALLOWED_ORIGINS: https://localhost:3000,https://grand-cajeta-92ed93.netlify.app

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "serve": "npx tsc && node dist/server.js"
+    "comp": "npx tsc",
+    "serve": "node dist/server.js",
+    "comp:serve": "npm run comp && npm run serve"
   },
   "author": "Noah McGraw",
   "license": "ISC",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import cors from 'cors'
-import https from 'https'
-import http from 'http'
-import fs from 'fs'
+// import https from 'https'
+// import http from 'http'
+// import fs from 'fs'
 import dotenv from 'dotenv'
 import { buildTranslationsList } from './services/integration-bridge/bridge'
 import { getSearchSuggestions } from './services/datamuse/datamuse'
@@ -20,32 +20,36 @@ app.use(cors())
 // Enable origin checker middleware
 app.use(originChecker)
 
-const httpsPort = process.env.VITE_HTTPS_PORT || 443
-const httpPort = process.env.VITE_HTTP_PORT || 80
+// const httpsPort = process.env.HTTPS_PORT || 443
+const httpPort = process.env.PORT || 80
 
-// Create HTTPS server
-https
-  .createServer(
-    {
-      // Grab paths to SSL cert and private key from environment variables
-      cert: fs.readFileSync(`${process.env.VITE_PATH_TO_SSL_CERT}`),
-      key: fs.readFileSync(`${process.env.VITE_PATH_TO_SSL_KEY}`),
-    },
-    app
-  )
-  .listen(httpsPort, () => {
-    console.log(`Https Server is listening on port ${httpsPort}.`)
-  })
+// // Create HTTPS server
+// https
+//   .createServer(
+//     {
+//       // Grab paths to SSL cert and private key from environment variables
+//       cert: fs.readFileSync(`${process.env.VITE_PATH_TO_SSL_CERT}`),
+//       key: fs.readFileSync(`${process.env.VITE_PATH_TO_SSL_KEY}`),
+//     },
+//     app
+//   )
+//   .listen(httpsPort, () => {
+//     console.log(`Https Server is listening on port ${httpsPort}.`)
+//   })
 
-// Create HTTP server to redirect all HTTP requests to HTTPS
-http
-  .createServer((req, res) => {
-    res.writeHead(301, { Location: 'https://' + req.headers['host'] + req.url })
-    res.end()
-  })
-  .listen(httpPort, () => {
-    console.log(`Http Server is listening on port ${httpPort}.`)
-  })
+// // Create HTTP server to redirect all HTTP requests to HTTPS
+// http
+//   .createServer((req, res) => {
+//     res.writeHead(301, { Location: 'https://' + req.headers['host'] + req.url })
+//     res.end()
+//   })
+//   .listen(httpPort, () => {
+//     console.log(`Http Server is listening on port ${httpPort}.`)
+//   })
+
+app.listen(httpPort, () => {
+  console.log(`Http Server is listening on port ${httpPort}.`)
+})
 
 // Provide a basic endpoint for testing
 app.get('/', (_req, res) => {


### PR DESCRIPTION
This PR sets up the API code to be deployed to a gcloud app engine service with the inclusion of gcloudignore and some renaming of scripts. It also resets the use of the https and http servers since App Engine takes care of requiring https connections for us.